### PR TITLE
Support using a Set as an enumeration of acceptable values

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,7 +340,8 @@ base Classy Hash syntax.
 
 ##### Enumeration
 
-The simplest generator checks for a set of exact values.
+As of version 0.2.0, the `enum` generator is a deprecated compatibility method
+that generates a `Set`.  See the above documentation for `Set` constraints.
 
 ```ruby
 # Enumerator -- value must be one of the elements provided

--- a/README.md
+++ b/README.md
@@ -217,6 +217,22 @@ ClassyHash.validate({ key1: 1 }, schema) # Okay
 ClassyHash.validate({ key1: 2 }, schema) # Throws ":key1 is not an odd integer"
 ```
 
+#### Sets
+
+Added in version 0.2.0, `Set`s constrain a value to one of a list of values.
+The `Set` constraint replaces the `enum` generator.  Note that a `Set` requires
+an *exact* value match, unlike the Multiple Choice constraint.
+
+```ruby
+schema = {
+  key1: Set.new([1, 2, 3, 'see?'])
+}
+
+ClassyHash.validate({ key1: 1 }, schema) # Okay
+ClassyHash.validate({ key1: 'see?' }, schema) # Okay
+ClassyHash.validate({ key1: 4 }, schema) # Throws ":key1 is not an element of [1, 2, 3, 'see?']"
+```
+
 #### Nested schemas
 
 Classy Hash accepts nested schemas.  You can also use a schema as one of the

--- a/lib/classy_hash.rb
+++ b/lib/classy_hash.rb
@@ -1,7 +1,9 @@
 # Classy Hash: Keep Your Hashes Classy
 # Created May 2014 by Mike Bourgeous, DeseretBook.com
-# Copyright (C)2014 Deseret Book
+# Copyright (C)2016 Deseret Book
 # See LICENSE and README.md for details.
+
+require 'set'
 
 # This module contains the ClassyHash methods for making sure Ruby Hash objects
 # match a given schema.  ClassyHash runs fast by taking advantage of Ruby
@@ -150,6 +152,12 @@ module ClassyHash
 
       unless constraint.cover?(value)
         self.raise_error(parent_path, key, "in range #{constraint.inspect}")
+      end
+
+    when Set
+      # Set/enumeration
+      unless constraint.include?(value)
+        self.raise_error(parent_path, key, "an element of #{constraint.to_a.inspect}")
       end
 
     when :optional

--- a/lib/classy_hash/generate.rb
+++ b/lib/classy_hash/generate.rb
@@ -5,8 +5,10 @@ module ClassyHash
   # This module contains helpers that generate constraints for common
   # ClassyHash validation tasks.
   module Generate
-    # Generates a ClassyHash constraint that ensures a value is equal to one of
-    # the arguments in +args+.
+    # Deprecated.  Generates a ClassyHash constraint that ensures a value is
+    # equal to one of the arguments in +args+.
+    #
+    # For new schemas, consider creating a Set with the enumeration elements.
     #
     # Example:
     #     schema = {
@@ -14,9 +16,7 @@ module ClassyHash
     #     }
     #     ClassyHash.validate({ a: 1 }, schema)
     def self.enum(*args)
-      lambda {|v|
-        args.include?(v) || "an element of #{args.inspect}"
-      }
+      Set.new(args)
     end
 
     # Generates a constraint that imposes a length limitation (an exact length

--- a/spec/lib/classy_hash_spec.rb
+++ b/spec/lib/classy_hash_spec.rb
@@ -681,6 +681,26 @@ describe ClassyHash do
       expect{ ClassyHash.validate({a: 1}, {a: 'a'..'z'}) }.to raise_error(/String/)
     end
 
+    it 'accepts valid values using a Set' do
+      expect{ ClassyHash.validate({a: 1}, {a: Set.new([1, '2', 3, nil])}) }.not_to raise_error
+      expect{ ClassyHash.validate({a: '2'}, {a: Set.new([1, '2', 3, nil])}) }.not_to raise_error
+      expect{ ClassyHash.validate({a: 3}, {a: Set.new([1, '2', 3, nil])}) }.not_to raise_error
+      expect{ ClassyHash.validate({a: nil}, {a: Set.new([1, '2', 3, nil])}) }.not_to raise_error
+    end
+
+    it 'rejects invalid values using a Set' do
+      # Empty set
+      expect{ ClassyHash.validate({a: 1}, {a: Set.new}) }.to raise_error(/element.*\[\]/)
+      expect{ ClassyHash.validate({a: nil}, {a: Set.new}) }.to raise_error(/element.*\[\]/)
+      expect{ ClassyHash.validate({b: :missing}, {a: Set.new}) }.to raise_error(/not present/)
+
+      # Non-empty set
+      expect{ ClassyHash.validate({a: '1'}, {a: Set.new([1, '2', 3, nil])}) }.to raise_error(/element/)
+      expect{ ClassyHash.validate({a: 2}, {a: Set.new([1, '2', 3, nil])}) }.to raise_error(/element/)
+      expect{ ClassyHash.validate({a: nil}, {a: Set.new([1, '2', 3])}) }.to raise_error(/element/)
+      expect{ ClassyHash.validate({b: :missing}, {a: Set.new([1, '2', 3, nil])}) }.to raise_error(/not present/)
+    end
+
     it 'rejects non-hashes' do
       expect{ ClassyHash.validate(false, {}) }.to raise_error(/hash/i)
       expect{ ClassyHash.validate({}, false) }.to raise_error(/hash/i)


### PR DESCRIPTION
This PR deprecates `CH::G.enum` and adds support for using `Set` to constrain a value to be an element of a specific set.  See the README changes for usage details.

Fixes https://github.com/deseretbook/classy_hash/issues/8