### PR TITLE
Composite and negative constraints

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,3 +24,7 @@ gem 'simplecov', '~> 0.12.0', require: false, group: :test
 
 # Code Climate for online test coverage
 gem 'codeclimate-test-reporter', require: false, group: :test
+
+# Pry for debugging while developing
+gem 'pry', require: false, group: :development
+gem 'pry-byebug', require: false, group: :development, platforms: :mri

--- a/bin/console
+++ b/bin/console
@@ -9,8 +9,9 @@ require "classy_hash"
 # with your gem easier. You can also use a different console, if you like.
 
 # (If you use this, don't forget to add pry to your Gemfile!)
-# require "pry"
-# Pry.start
+require 'pry'
+require 'pry-byebug'
+Pry.start
 
-require "irb"
-IRB.start
+# require "irb"
+# IRB.start

--- a/lib/classy_hash.rb
+++ b/lib/classy_hash.rb
@@ -160,6 +160,16 @@ module ClassyHash
         self.raise_error(parent_path, key, "an element of #{constraint.to_a.inspect}")
       end
 
+    when CH::G::Composite
+      constraint.constraints.each do |c|
+        # TODO: negative constraints
+        begin
+          self.check_one(key, value, c, parent_path)
+        rescue => e
+          self.raise_error(parent_path, key, constraint.describe(value))
+        end
+      end
+
     when :optional
       # Optional key marker in multiple choice validators
       nil

--- a/lib/classy_hash/generate.rb
+++ b/lib/classy_hash/generate.rb
@@ -11,7 +11,7 @@ module ClassyHash
       attr_reader :constraints
 
       # True if the constraints must all not match, false if they must all
-      # match.  TODO: implement
+      # match.
       attr_reader :negate
 
       # Initializes a composite constraint with the given Array of
@@ -27,14 +27,14 @@ module ClassyHash
       # Returns a String describing the composite constraint failing against
       # the given +value+.
       def describe(value)
-        # FIXME: multiconstraint_string will give the wrong value for procs here if value isn't given
-        # TODO: find a way to cache?
-        "#{negate ? 'none' : 'all'} of #{CH.multiconstraint_string(constraints, nil)}"
+        "#{negate ? 'none' : 'all'} of [#{CH.multiconstraint_string(constraints, value)}]"
       end
     end
 
     # Generates a constraint that requires a value to match *all* of the given
-    # constraints.
+    # constraints.  If no constraints are given, always passes.
+    #
+    # Raises an error if no constraints are given.
     #
     # Example:
     #     schema = {
@@ -47,6 +47,8 @@ module ClassyHash
 
     # Generates a constraint that requires a value to match *none* of the given
     # constraints.
+    #
+    # Raises an error if no constraints are given.
     #
     # Example:
     #     schema = {

--- a/lib/classy_hash/generate.rb
+++ b/lib/classy_hash/generate.rb
@@ -5,6 +5,58 @@ module ClassyHash
   # This module contains helpers that generate constraints for common
   # ClassyHash validation tasks.
   module Generate
+    # Used by the .all and .not generators.  Do not use directly.
+    class Composite
+      # Array of constraints to apply together.
+      attr_reader :constraints
+
+      # True if the constraints must all not match, false if they must all
+      # match.  TODO: implement
+      attr_reader :negate
+
+      # Initializes a composite constraint with the given Array of
+      # +constraints+.  If +negate+ is true, then the constraints must all fail
+      # for the value to pass.
+      def initialize(constraints, negate = false)
+        raise 'No constraints were given' if constraints.empty?
+
+        @constraints = constraints
+        @negate = negate
+      end
+
+      # Returns a String describing the composite constraint failing against
+      # the given +value+.
+      def describe(value)
+        # FIXME: multiconstraint_string will give the wrong value for procs here if value isn't given
+        # TODO: find a way to cache?
+        "#{negate ? 'none' : 'all'} of #{CH.multiconstraint_string(constraints, nil)}"
+      end
+    end
+
+    # Generates a constraint that requires a value to match *all* of the given
+    # constraints.
+    #
+    # Example:
+    #     schema = {
+    #       a: CH::G.all(Integer, 1..100, CH::G.not(Set.new([7, 13])))
+    #     }
+    #     ClassyHash.validate({ a: 25 }, schema)
+    def self.all(*constraints)
+      Composite.new(constraints.freeze)
+    end
+
+    # Generates a constraint that requires a value to match *none* of the given
+    # constraints.
+    #
+    # Example:
+    #     schema = {
+    #       a: CH::G.not(Rational, BigDecimal)
+    #     }
+    #     ClassyHash.validate({ a: 1.25 }, schema)
+    def self.not(*constraints)
+      Composite.new(constraints.freeze, true)
+    end
+
     # Deprecated.  Generates a ClassyHash constraint that ensures a value is
     # equal to one of the arguments in +args+.
     #

--- a/spec/lib/classy_hash/generate_spec.rb
+++ b/spec/lib/classy_hash/generate_spec.rb
@@ -1,9 +1,85 @@
 # Classy Hash: Keep Your Hashes Classy (Generators RSpec test suite)
 # Created June 2014 by Mike Bourgeous, DeseretBook.com
-# Copyright (C)2014 Deseret Book
+# Copyright (C)2016 Deseret Book
 # See LICENSE and README.md for details.
 
+require 'rational'
+require 'bigdecimal'
+
 describe CH::G do
+  describe '.all' do
+    let(:schema) {
+      {
+        str: [:optional, CH::G.all(String, 'a'..'z', ->(v){ v.respond_to?(:length) && v.length.odd? ? true : 'odd length' })],
+        int: [:optional, CH::G.all(Integer, 1..100, CH::G.not(Set.new([7, 13])))],
+        nil: [:optional, CH::G.all(NilClass)],
+      }
+    }
+
+    it 'accepts values matching all constraints' do
+      expect{ CH.validate({ str: 'hello' }, schema) }.not_to raise_error
+      expect{ CH.validate({ str: 'a' }, schema) }.not_to raise_error
+      expect{ CH.validate({ str: 'z' }, schema) }.not_to raise_error
+
+      expect{ CH.validate({ int: 1 }, schema) }.not_to raise_error
+      expect{ CH.validate({ int: 10 }, schema) }.not_to raise_error
+      expect{ CH.validate({ int: 100 }, schema) }.not_to raise_error
+
+      expect{ CH.validate({ nil: nil }, schema) }.not_to raise_error
+    end
+
+    it 'rejects values not matching all constraints' do
+      expect{ CH.validate({ str: 3 }, schema) }.to raise_error(/all of.*String.*/)
+      expect{ CH.validate({ str: :invalid }, schema) }.to raise_error(/all of.*String.*/)
+      expect{ CH.validate({ str: 'hi' }, schema) }.to raise_error(/all of.*String.*odd length/)
+      expect{ CH.validate({ str: 'A' }, schema) }.to raise_error(/all of.*String.*Proc/)
+
+      expect{ CH.validate({ int: 0 }, schema) }.to raise_error(/all of.*Integer/)
+      expect{ CH.validate({ int: 10.5 }, schema) }.to raise_error(/all of.*Integer/)
+      expect{ CH.validate({ int: 101 }, schema) }.to raise_error(/all of.*Integer/)
+      expect{ CH.validate({ int: '50' }, schema) }.to raise_error(/all of.*Integer/)
+
+      expect{ CH.validate({ nil: :nil }, schema) }.to raise_error(/all of.*Nil/)
+    end
+
+    it 'raises an error if no constraints are given' do
+      expect{ CH::G.all }.to raise_error(/No constraints/)
+    end
+  end
+
+  describe '.not' do
+    let(:not_schema) { { not: CH::G.not(Rational, BigDecimal, String, 10.0..20.0) } }
+    let(:single_schema) { { single: CH::G.not(String) } }
+
+    it 'accepts values not matching any constraints' do
+      expect{ CH.validate({ not: 9 }, not_schema) }.not_to raise_error
+      expect{ CH.validate({ not: -5.5 }, not_schema) }.not_to raise_error
+      expect{ CH.validate({ not: :symbol }, not_schema) }.not_to raise_error
+      expect{ CH.validate({ not: Object }, not_schema) }.not_to raise_error
+      expect{ CH.validate({ not: nil }, not_schema) }.not_to raise_error
+
+      expect{ CH.validate({ single: String }, single_schema) }.not_to raise_error
+      expect{ CH.validate({ single: :String }, single_schema) }.not_to raise_error
+      expect{ CH.validate({ single: 123 }, single_schema) }.not_to raise_error
+      expect{ CH.validate({ single: nil }, single_schema) }.not_to raise_error
+    end
+
+    it 'rejects values matching one or more constraints' do
+      expect{ CH.validate({ not: Rational(3, 5) }, not_schema) }.to raise_error(/:not.*none of.*Rational.*BigDecimal.*String/)
+      expect{ CH.validate({ not: BigDecimal.new('0.25') }, not_schema) }.to raise_error(/:not.*none of.*Rational.*BigDecimal.*String/)
+      expect{ CH.validate({ not: 'A string' }, not_schema) }.to raise_error(/:not.*none of.*Rational.*BigDecimal.*String/)
+      expect{ CH.validate({ not: 13.0 }, not_schema) }.to raise_error(/:not.*none of.*Rational.*BigDecimal.*String/)
+      expect{ CH.validate({ not: 13 }, not_schema) }.to raise_error(/:not.*none of.*Rational.*BigDecimal.*String/)
+
+      expect{ CH.validate({ single: 'valid' }, single_schema) }.to raise_error(/:single.*none of.*String/)
+      expect{ CH.validate({ single: '' }, single_schema) }.to raise_error(/:single.*none of.*String/)
+    end
+
+    it 'raises an error if no constraints are given' do
+      expect{ CH::G.not }.to raise_error(/No constraints/)
+    end
+  end
+
   describe '.enum' do
     let(:int_schema) do
       { a: CH::G.enum(1, 2, 3, 4, 5) }

--- a/spec/lib/classy_hash_spec.rb
+++ b/spec/lib/classy_hash_spec.rb
@@ -1,6 +1,6 @@
 # Classy Hash: Keep Your Hashes Classy (RSpec test suite)
 # Created May 2014 by Mike Bourgeous, DeseretBook.com
-# Copyright (C)2014 Deseret Book
+# Copyright (C)2016 Deseret Book
 # See LICENSE and README.md for details.
 
 describe ClassyHash do


### PR DESCRIPTION
This PR adds support for composite constraints via `CH::G.all`, and negated constraints via `CH::G.not`.  Fixes #2.

- [x] Implementation
- [x] Tests
- [x] README documentation