### PR TITLE
Use a specific custom Exception subclass

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,8 @@ ClassyHash.validate(hash, schema) # Throws ":key2 is not a/an Integer"
 
 The `validate` and `validate_strict` methods will raise an exception if
 validation fails.  Validation proceeds until the first invalid value is found,
-then an error is thrown for that value.  Later values are not checked.
+then an error (ClassyHash::ValidationError) is thrown for that value.  
+Later values are not checked.
 
 
 #### Multiple choice

--- a/lib/classy_hash.rb
+++ b/lib/classy_hash.rb
@@ -10,8 +10,8 @@ module ClassyHash
   # Validates a +hash+ against a +schema+.  The +parent_path+ parameter is used
   # internally to generate error messages.
   def self.validate(hash, schema, parent_path=nil)
-    raise 'Must validate a Hash' unless hash.is_a?(Hash) # TODO: Allow validating other types by passing to #check_one?
-    raise 'Schema must be a Hash' unless schema.is_a?(Hash) # TODO: Allow individual element validations?
+    error 'Must validate a Hash' unless hash.is_a?(Hash) # TODO: Allow validating other types by passing to #check_one?
+    error 'Schema must be a Hash' unless schema.is_a?(Hash) # TODO: Allow individual element validations?
 
     schema.each do |key, constraint|
       if hash.include?(key)
@@ -28,15 +28,15 @@ module ClassyHash
   # Only the top-level schema is strictly validated.  If +verbose+ is true, the
   # names of unexpected keys will be included in the error message.
   def self.validate_strict(hash, schema, verbose=false, parent_path=nil)
-    raise 'Must validate a Hash' unless hash.is_a?(Hash) # TODO: Allow validating other types by passing to #check_one?
-    raise 'Schema must be a Hash' unless schema.is_a?(Hash) # TODO: Allow individual element validations?
+    error 'Must validate a Hash' unless hash.is_a?(Hash) # TODO: Allow validating other types by passing to #check_one?
+    error 'Schema must be a Hash' unless schema.is_a?(Hash) # TODO: Allow individual element validations?
 
     extra_keys = hash.keys - schema.keys
     unless extra_keys.empty?
       if verbose
-        raise "Hash contains members (#{extra_keys.map(&:inspect).join(', ')}) not specified in schema"
+        error "Hash contains members (#{extra_keys.map(&:inspect).join(', ')}) not specified in schema"
       else
-        raise 'Hash contains members not specified in schema'
+        error 'Hash contains members not specified in schema'
       end
     end
 
@@ -65,7 +65,7 @@ module ClassyHash
         # Throw schema and array errors immediately
         if (c.is_a?(Hash) && value.is_a?(Hash)) ||
           (c.is_a?(Array) && value.is_a?(Array) && c.length == 1 && c.first.is_a?(Array))
-          raise e
+          error e
         end
       end
     end
@@ -172,8 +172,14 @@ module ClassyHash
   # +parent_path+ fails because the value "is not #{+message+}".
   def self.raise_error(parent_path, key, message)
     # TODO: Ability to validate all keys
-    raise "#{self.join_path(parent_path, key)} is not #{message}"
+    error "#{self.join_path(parent_path, key)} is not #{message}"
   end
+
+  def self.error(msg)
+    raise ValidationError, msg
+  end
+
+  class ValidationError < StandardError; end
 end
 
 require 'classy_hash/generate'

--- a/lib/classy_hash.rb
+++ b/lib/classy_hash.rb
@@ -9,13 +9,24 @@
 module ClassyHash
   # Validates a +hash+ against a +schema+.  The +parent_path+ parameter is used
   # internally to generate error messages.
-  def self.validate(hash, schema, parent_path=nil)
+  def self.validate(hash, schema, parent_path=nil, verbose: false, strict: false)
     error 'Must validate a Hash' unless hash.is_a?(Hash) # TODO: Allow validating other types by passing to #check_one?
     error 'Schema must be a Hash' unless schema.is_a?(Hash) # TODO: Allow individual element validations?
 
+    if strict
+      extra_keys = hash.keys - schema.keys
+      unless extra_keys.empty?
+        if verbose
+          error "Hash contains members (#{extra_keys.map(&:inspect).join(', ')}) not specified in schema"
+        else
+          error 'Hash contains members not specified in schema'
+        end
+      end
+    end
+
     schema.each do |key, constraint|
       if hash.include?(key)
-        self.check_one(key, hash[key], constraint, parent_path)
+        self.check_one(key, hash[key], constraint, parent_path, verbose: verbose, strict: strict)
       elsif !(constraint.is_a?(Array) && constraint.include?(:optional))
         self.raise_error(parent_path, key, "present")
       end
@@ -27,27 +38,13 @@ module ClassyHash
   # As with #validate, but members not specified in the +schema+ are forbidden.
   # Only the top-level schema is strictly validated.  If +verbose+ is true, the
   # names of unexpected keys will be included in the error message.
-  def self.validate_strict(hash, schema, verbose=false, parent_path=nil)
-    error 'Must validate a Hash' unless hash.is_a?(Hash) # TODO: Allow validating other types by passing to #check_one?
-    error 'Schema must be a Hash' unless schema.is_a?(Hash) # TODO: Allow individual element validations?
-
-    extra_keys = hash.keys - schema.keys
-    unless extra_keys.empty?
-      if verbose
-        error "Hash contains members (#{extra_keys.map(&:inspect).join(', ')}) not specified in schema"
-      else
-        error 'Hash contains members not specified in schema'
-      end
-    end
-
-    # TODO: Strict validation for nested schemas as well
-
-    self.validate(hash, schema, parent_path)
+  def self.validate_strict(hash, schema, verbose=false)
+    validate(hash, schema, nil, verbose:verbose, strict: true)
   end
 
   # Raises an error unless the given +value+ matches one of the given multiple
   # choice +constraints+.
-  def self.check_multi(key, value, constraints, parent_path=nil)
+  def self.check_multi(key, value, constraints, parent_path=nil, verbose: false, strict: false)
     if constraints.length == 0
         self.raise_error(parent_path, key, "a valid multiple choice constraint (array must not be empty)")
     end
@@ -59,7 +56,7 @@ module ClassyHash
     constraints.each do |c|
       next if c == :optional
       begin
-        self.check_one(key, value, c, parent_path)
+        self.check_one(key, value, c, parent_path, verbose: verbose, strict: strict)
         return
       rescue => e
         # Throw schema and array errors immediately
@@ -93,7 +90,7 @@ module ClassyHash
   end
 
   # Checks a single value against a single constraint.
-  def self.check_one(key, value, constraint, parent_path=nil)
+  def self.check_one(key, value, constraint, parent_path=nil, verbose: false, strict: false)
     case constraint
     when Class
       # Constrain value to be a specific class
@@ -108,7 +105,7 @@ module ClassyHash
     when Hash
       # Recursively check nested Hashes
       self.raise_error(parent_path, key, "a Hash") unless value.is_a?(Hash)
-      self.validate(value, constraint, self.join_path(parent_path, key))
+      self.validate(value, constraint, self.join_path(parent_path, key), verbose:verbose, strict:strict)
 
     when Array
       # Multiple choice or array validation
@@ -118,11 +115,11 @@ module ClassyHash
 
         constraints = constraint.first
         value.each_with_index do |v, idx|
-          self.check_multi(idx, v, constraints, self.join_path(parent_path, key))
+          self.check_multi(idx, v, constraints, self.join_path(parent_path, key), verbose: verbose, strict: strict)
         end
       else
         # Multiple choice
-        self.check_multi(key, value, constraint, parent_path)
+        self.check_multi(key, value, constraint, parent_path, verbose: verbose, strict: strict)
       end
 
     when Regexp

--- a/lib/classy_hash/generate.rb
+++ b/lib/classy_hash/generate.rb
@@ -30,10 +30,10 @@ module ClassyHash
     #     ClassyHash.validate({a: '12345'}, schema)
     #     ClassyHash.validate({a: [1, 2, 3, 4, 5]}, schema)
     def self.length(length)
-      raise "length must be an Integer or a Range" unless length.is_a?(Integer) || length.is_a?(Range)
+      ClassyHash.error "length must be an Integer or a Range" unless length.is_a?(Integer) || length.is_a?(Range)
 
       if length.is_a?(Range) && !(length.min.is_a?(Integer) && length.max.is_a?(Integer))
-        raise "Range length endpoints must be Integers"
+        ClassyHash.error "range length endpoints must be Integers"
       end
 
       lambda {|v|
@@ -58,7 +58,7 @@ module ClassyHash
     #     }
     #     ClassyHash.validate({ a: [ 1, 2, 3, 'four', 5 ] }, schema)
     def self.array_length(length, *constraints)
-      raise 'one or more constraints must be provided' if constraints.empty?
+      ClassyHash.error 'one or more constraints must be provided' if constraints.empty?
 
       length_lambda = self.length(length)
       msg = "an Array of length #{length}"

--- a/spec/lib/classy_hash_spec.rb
+++ b/spec/lib/classy_hash_spec.rb
@@ -515,11 +515,11 @@ describe ClassyHash do
     end
 
     it 'rejects basic invalid values' do
-      expect{ ClassyHash.validate({a: nil}, {a: String}) }.to raise_error(/not.*String/)
-      expect{ ClassyHash.validate({a: 3}, {a: String}) }.to raise_error(/not.*String/)
-      expect{ ClassyHash.validate({a: false}, {a: Numeric}) }.to raise_error(/not.*Numeric/)
-      expect{ ClassyHash.validate({a: {q: :q}}, {a: Array}) }.to raise_error(/not.*Array/)
-      expect{ ClassyHash.validate({a: [:q, :q]}, {a: Hash}) }.to raise_error(/not.*Hash/)
+      expect{ ClassyHash.validate({a: nil}, {a: String}) }.to raise_error(ClassyHash::ValidationError, /not.*String/)
+      expect{ ClassyHash.validate({a: 3}, {a: String}) }.to raise_error(ClassyHash::ValidationError, /not.*String/)
+      expect{ ClassyHash.validate({a: false}, {a: Numeric}) }.to raise_error(ClassyHash::ValidationError, /not.*Numeric/)
+      expect{ ClassyHash.validate({a: {q: :q}}, {a: Array}) }.to raise_error(ClassyHash::ValidationError, /not.*Array/)
+      expect{ ClassyHash.validate({a: [:q, :q]}, {a: Hash}) }.to raise_error(ClassyHash::ValidationError, /not.*Hash/)
     end
 
     it 'accepts fixnum, bignum, float, and rational for numeric' do
@@ -531,9 +531,9 @@ describe ClassyHash do
 
     it 'rejects float, bignum, and rational for fixnum' do
       # TODO: Ruby 2.4 merges Bignum and Fixnum into Integer
-      expect{ ClassyHash.validate({a: 1.0}, {a: Fixnum}) }.to raise_error(/not.*(Integer|Fixnum)/)
-      expect{ ClassyHash.validate({a: 1<<200}, {a: Fixnum}) }.to raise_error(/not.*(Integer|Fixnum)/)
-      expect{ ClassyHash.validate({a: Rational(1, 3)}, {a: Fixnum}) }.to raise_error(/not.*(Integer|Fixnum)/)
+      expect{ ClassyHash.validate({a: 1.0}, {a: Fixnum}) }.to raise_error(ClassyHash::ValidationError, /not.*(Integer|Fixnum)/)
+      expect{ ClassyHash.validate({a: 1<<200}, {a: Fixnum}) }.to raise_error(ClassyHash::ValidationError, /not.*(Integer|Fixnum)/)
+      expect{ ClassyHash.validate({a: Rational(1, 3)}, {a: Fixnum}) }.to raise_error(ClassyHash::ValidationError, /not.*(Integer|Fixnum)/)
     end
 
     it 'accepts valid multiple choice values' do
@@ -545,10 +545,10 @@ describe ClassyHash do
     end
 
     it 'rejects invalid multiple choice values' do
-      expect{ ClassyHash.validate({a: nil}, {a: [String]}) }.to raise_error(/one of.*String/)
-      expect{ ClassyHash.validate({a: false}, {a: [NilClass]}) }.to raise_error(/one of.*Nil/)
-      expect{ ClassyHash.validate({a: 1}, {a: [String]}) }.to raise_error(/one of.*String/)
-      expect{ ClassyHash.validate({a: 1}, {a: [String, Rational, NilClass]}) }.to raise_error(/one of.*String.*Rational.*Nil/)
+      expect{ ClassyHash.validate({a: nil}, {a: [String]}) }.to raise_error(ClassyHash::ValidationError, /one of.*String/)
+      expect{ ClassyHash.validate({a: false}, {a: [NilClass]}) }.to raise_error(ClassyHash::ValidationError, /one of.*Nil/)
+      expect{ ClassyHash.validate({a: 1}, {a: [String]}) }.to raise_error(ClassyHash::ValidationError, /one of.*String/)
+      expect{ ClassyHash.validate({a: 1}, {a: [String, Rational, NilClass]}) }.to raise_error(ClassyHash::ValidationError, /one of.*String.*Rational.*Nil/)
     end
 
     it 'accepts both true and false for just TrueClass or just FalseClass' do
@@ -562,10 +562,10 @@ describe ClassyHash do
     end
 
     it 'rejects invalid values for TrueClass and FalseClass' do
-      expect{ ClassyHash.validate({a: 1}, {a: TrueClass}) }.to raise_error(/true or false/)
-      expect{ ClassyHash.validate({a: 0}, {a: FalseClass}) }.to raise_error(/true or false/)
-      expect{ ClassyHash.validate({a: 1}, {a: [TrueClass]}) }.to raise_error(/one of.*true or false/)
-      expect{ ClassyHash.validate({a: 0}, {a: [FalseClass]}) }.to raise_error(/one of.*true or false/)
+      expect{ ClassyHash.validate({a: 1}, {a: TrueClass}) }.to raise_error(ClassyHash::ValidationError, /true or false/)
+      expect{ ClassyHash.validate({a: 0}, {a: FalseClass}) }.to raise_error(ClassyHash::ValidationError, /true or false/)
+      expect{ ClassyHash.validate({a: 1}, {a: [TrueClass]}) }.to raise_error(ClassyHash::ValidationError, /one of.*true or false/)
+      expect{ ClassyHash.validate({a: 0}, {a: [FalseClass]}) }.to raise_error(ClassyHash::ValidationError, /one of.*true or false/)
     end
 
     it 'requires both TrueClass and FalseClass for true or false in multiple choices' do
@@ -581,10 +581,10 @@ describe ClassyHash do
     end
 
     it 'rejects invalid single-choice arrays' do
-      expect{ ClassyHash.validate({a: [nil]}, {a: [[String]]}) }.to raise_error(/\[0\].*String/)
-      expect{ ClassyHash.validate({a: ['hi', 'hello', 'heya', :optional]}, {a: [[String]]}) }.to raise_error(/\[3\].*String/)
-      expect{ ClassyHash.validate({a: [1]}, {a: [[String]]}) }.to raise_error(/\[0\].*String/)
-      expect{ ClassyHash.validate({a: [1, 2, 3, '']}, {a: [[Integer]]}) }.to raise_error(/\[3\].*Integer/)
+      expect{ ClassyHash.validate({a: [nil]}, {a: [[String]]}) }.to raise_error(ClassyHash::ValidationError, /\[0\].*String/)
+      expect{ ClassyHash.validate({a: ['hi', 'hello', 'heya', :optional]}, {a: [[String]]}) }.to raise_error(ClassyHash::ValidationError, /\[3\].*String/)
+      expect{ ClassyHash.validate({a: [1]}, {a: [[String]]}) }.to raise_error(ClassyHash::ValidationError, /\[0\].*String/)
+      expect{ ClassyHash.validate({a: [1, 2, 3, '']}, {a: [[Integer]]}) }.to raise_error(ClassyHash::ValidationError, /\[3\].*Integer/)
     end
 
     it 'accepts valid multiple-choice arrays' do
@@ -597,10 +597,10 @@ describe ClassyHash do
 
     it 'rejects invalid multiple-choice arrays' do
       schema = { a: [[String, TrueClass, Float]] }
-      expect{ ClassyHash.validate({a: [nil]}, schema) }.to raise_error(/\[0\].*String.*true or false.*Float/)
-      expect{ ClassyHash.validate({a: ['hi', 'hello', 'heya', :optional]}, schema) }.to raise_error(/\[3\].*String.*true or false.*Float/)
-      expect{ ClassyHash.validate({a: [1]}, schema) }.to raise_error(/\[0\].*String.*true or false.*Float/)
-      expect{ ClassyHash.validate({a: [1, 2, 3, '']}, {a: [[Integer, Float]]}) }.to raise_error(/\[3\].*Integer.*Float/)
+      expect{ ClassyHash.validate({a: [nil]}, schema) }.to raise_error(ClassyHash::ValidationError, /\[0\].*String.*true or false.*Float/)
+      expect{ ClassyHash.validate({a: ['hi', 'hello', 'heya', :optional]}, schema) }.to raise_error(ClassyHash::ValidationError, /\[3\].*String.*true or false.*Float/)
+      expect{ ClassyHash.validate({a: [1]}, schema) }.to raise_error(ClassyHash::ValidationError, /\[0\].*String.*true or false.*Float/)
+      expect{ ClassyHash.validate({a: [1, 2, 3, '']}, {a: [[Integer, Float]]}) }.to raise_error(ClassyHash::ValidationError, /\[3\].*Integer.*Float/)
     end
 
     it 'accepts valid arrays with schemas' do
@@ -608,19 +608,19 @@ describe ClassyHash do
     end
 
     it 'rejects invalid arrays with schemas' do
-      expect { ClassyHash.validate({a: [{c: 1}, {b: 2.1}, 5]}, {a: [[{b: Numeric}, Integer]]}) }.to raise_error(/present/)
-      expect { ClassyHash.validate({a: [{b: 1}, {b: 2.1}, 5.0]}, {a: [[{b: Numeric}, Integer]]}) }.to raise_error(/\[2\]/)
+      expect { ClassyHash.validate({a: [{c: 1}, {b: 2.1}, 5]}, {a: [[{b: Numeric}, Integer]]}) }.to raise_error(ClassyHash::ValidationError, /present/)
+      expect { ClassyHash.validate({a: [{b: 1}, {b: 2.1}, 5.0]}, {a: [[{b: Numeric}, Integer]]}) }.to raise_error(ClassyHash::ValidationError, /\[2\]/)
     end
 
     it 'handles more than one key' do
       expect{ ClassyHash.validate({a: true, b: 'str'}, {a: TrueClass, b: String}) }.not_to raise_error
-      expect{ ClassyHash.validate({a: 'str', b: true}, {a: TrueClass, b: String}) }.to raise_error(/:a.*true or false/)
+      expect{ ClassyHash.validate({a: 'str', b: true}, {a: TrueClass, b: String}) }.to raise_error(ClassyHash::ValidationError, /:a.*true or false/)
     end
 
     it 'rejects hashes with missing keys' do
-      expect{ ClassyHash.validate({}, {a: NilClass}) }.to raise_error(/:a.*present/)
-      expect{ ClassyHash.validate({}, {a: Integer}) }.to raise_error(/:a.*present/)
-      expect{ ClassyHash.validate({a: 1}, {a: Integer, b: NilClass}) }.to raise_error(/:b.*present/)
+      expect{ ClassyHash.validate({}, {a: NilClass}) }.to raise_error(ClassyHash::ValidationError, /:a.*present/)
+      expect{ ClassyHash.validate({}, {a: Integer}) }.to raise_error(ClassyHash::ValidationError, /:a.*present/)
+      expect{ ClassyHash.validate({a: 1}, {a: Integer, b: NilClass}) }.to raise_error(ClassyHash::ValidationError, /:b.*present/)
     end
 
     it 'accepts valid or missing optional keys' do
@@ -637,29 +637,29 @@ describe ClassyHash do
     end
 
     it 'rejects invalid optional keys' do
-      expect{ ClassyHash.validate({a: nil}, {a: [:optional, Integer]}) }.to raise_error(/:a.*Integer/)
-      expect{ ClassyHash.validate({a: 'str'}, {a: [:optional, Integer]}) }.to raise_error(/:a.*Integer/)
-      expect{ ClassyHash.validate({a: :sym1}, {a: [:optional, Integer, String]}) }.to raise_error(/:a.*one of.*Integer.*String/)
+      expect{ ClassyHash.validate({a: nil}, {a: [:optional, Integer]}) }.to raise_error(ClassyHash::ValidationError, /:a.*Integer/)
+      expect{ ClassyHash.validate({a: 'str'}, {a: [:optional, Integer]}) }.to raise_error(ClassyHash::ValidationError, /:a.*Integer/)
+      expect{ ClassyHash.validate({a: :sym1}, {a: [:optional, Integer, String]}) }.to raise_error(ClassyHash::ValidationError, /:a.*one of.*Integer.*String/)
     end
 
     it 'rejects invalid optional arrays' do
-      expect{ ClassyHash.validate({a: [5.5]}, {a: [:optional, [[Integer]] ]}) }.to raise_error(/\[0\].*Integer/)
-      expect{ ClassyHash.validate({a: [1, 2, 3, 'str']}, {a: [:optional, [[Integer]] ]}) }.to raise_error(/\[3\]/)
+      expect{ ClassyHash.validate({a: [5.5]}, {a: [:optional, [[Integer]] ]}) }.to raise_error(ClassyHash::ValidationError, /\[0\].*Integer/)
+      expect{ ClassyHash.validate({a: [1, 2, 3, 'str']}, {a: [:optional, [[Integer]] ]}) }.to raise_error(ClassyHash::ValidationError, /\[3\]/)
     end
 
     it 'accepts missing optional member with proc that would always fail' do
       # We can ensure a member is *never* present with this construct
       expect{ ClassyHash.validate({}, {a: [:optional, lambda {|v| false}]}) }.not_to raise_error
-      expect{ ClassyHash.validate({a: nil}, {a: [:optional, lambda {|v| false}]}) }.to raise_error(/accepted by/)
+      expect{ ClassyHash.validate({a: nil}, {a: [:optional, lambda {|v| false}]}) }.to raise_error(ClassyHash::ValidationError, /accepted by/)
     end
 
     it 'accepts or rejects hashes using a proc' do
       expect{ ClassyHash.validate({a: 1}, {a: lambda {|v| v == 1}}) }.not_to raise_error
-      expect{ ClassyHash.validate({a: -1}, {a: lambda {|v| v == 1}}) }.to raise_error(/accepted by Proc/)
+      expect{ ClassyHash.validate({a: -1}, {a: lambda {|v| v == 1}}) }.to raise_error(ClassyHash::ValidationError, /accepted by Proc/)
     end
 
     it 'uses error messages returned by a proc' do
-      expect{ ClassyHash.validate({a: 1}, {a: lambda {|v| 'no way'}}) }.to raise_error(/no way/)
+      expect{ ClassyHash.validate({a: 1}, {a: lambda {|v| 'no way'}}) }.to raise_error(ClassyHash::ValidationError, /no way/)
     end
 
     it 'accepts valid values using a range' do
@@ -670,45 +670,45 @@ describe ClassyHash do
     end
 
     it 'rejects out-of-range values using a range' do
-      expect{ ClassyHash.validate({a: 0}, {a: 1..2}) }.to raise_error(/in range/)
-      expect{ ClassyHash.validate({a: Rational(1, 2)}, {a: 1.0..2.0}) }.to raise_error(/in range/)
-      expect{ ClassyHash.validate({a: 'spinach'}, {a: 'cabbage'..'cauliflower'}) }.to raise_error(/in range/)
-      expect{ ClassyHash.validate({a: [2, 1]}, {a: [0]..[2]}) }.to raise_error(/in range/)
+      expect{ ClassyHash.validate({a: 0}, {a: 1..2}) }.to raise_error(ClassyHash::ValidationError, /in range/)
+      expect{ ClassyHash.validate({a: Rational(1, 2)}, {a: 1.0..2.0}) }.to raise_error(ClassyHash::ValidationError, /in range/)
+      expect{ ClassyHash.validate({a: 'spinach'}, {a: 'cabbage'..'cauliflower'}) }.to raise_error(ClassyHash::ValidationError, /in range/)
+      expect{ ClassyHash.validate({a: [2, 1]}, {a: [0]..[2]}) }.to raise_error(ClassyHash::ValidationError, /in range/)
     end
 
     it 'rejects invalid types using a range' do
-      expect{ ClassyHash.validate({a: 1.0}, {a: 1..2}) }.to raise_error(/Integer/)
-      expect{ ClassyHash.validate({a: 1}, {a: 'a'..'z'}) }.to raise_error(/String/)
+      expect{ ClassyHash.validate({a: 1.0}, {a: 1..2}) }.to raise_error(ClassyHash::ValidationError, /Integer/)
+      expect{ ClassyHash.validate({a: 1}, {a: 'a'..'z'}) }.to raise_error(ClassyHash::ValidationError, /String/)
     end
 
     it 'rejects non-hashes' do
-      expect{ ClassyHash.validate(false, {}) }.to raise_error(/hash/i)
-      expect{ ClassyHash.validate({}, false) }.to raise_error(/hash/i)
+      expect{ ClassyHash.validate(false, {}) }.to raise_error(ClassyHash::ValidationError, /hash/i)
+      expect{ ClassyHash.validate({}, false) }.to raise_error(ClassyHash::ValidationError, /hash/i)
     end
 
     it 'rejects invalid schema elements' do
-      expect{ ClassyHash.validate({a: 1}, {a: :invalid}) }.to raise_error(/valid.*constraint/)
+      expect{ ClassyHash.validate({a: 1}, {a: :invalid}) }.to raise_error(ClassyHash::ValidationError, /valid.*constraint/)
     end
 
     it 'rejects empty multiple choice constraints' do
-      expect{ ClassyHash.validate({a: nil}, {a: []}) }.to raise_error(/choice.*empty/)
-      expect{ ClassyHash.validate({a: [1]}, {a: [[]]}) }.to raise_error(/choice.*empty/)
+      expect{ ClassyHash.validate({a: nil}, {a: []}) }.to raise_error(ClassyHash::ValidationError, /choice.*empty/)
+      expect{ ClassyHash.validate({a: [1]}, {a: [[]]}) }.to raise_error(ClassyHash::ValidationError, /choice.*empty/)
     end
 
     it 'accepts or rejects Strings using a partial-string regex' do
       schema = { a: /(in)?[1-9]{1,3}/ }
-      expect{ ClassyHash.validate({a: 3}, schema) }.to raise_error(/String.*match/)
+      expect{ ClassyHash.validate({a: 3}, schema) }.to raise_error(ClassyHash::ValidationError, /String.*match/)
       expect{ ClassyHash.validate({a: 3.to_s}, schema) }.not_to raise_error
-      expect{ ClassyHash.validate({a: nil}, schema) }.to raise_error(/String.*match/)
-      expect{ ClassyHash.validate({a: 'in0'}, schema) }.to raise_error(/String.*match/)
+      expect{ ClassyHash.validate({a: nil}, schema) }.to raise_error(ClassyHash::ValidationError, /String.*match/)
+      expect{ ClassyHash.validate({a: 'in0'}, schema) }.to raise_error(ClassyHash::ValidationError, /String.*match/)
       expect{ ClassyHash.validate({a: 'in1'}, schema) }.not_to raise_error
       expect{ ClassyHash.validate({a: 'the middle can be in923 ok'}, schema) }.not_to raise_error
     end
 
     it 'accepts or rejects Strings using a whole-string regex' do
       schema = { a: /\Athe.*string\z/i }
-      expect{ ClassyHash.validate({a: /the string/}, schema) }.to raise_error(/String.*match/)
-      expect{ ClassyHash.validate({a: 'not the string'}, schema) }.to raise_error(/String.*match/)
+      expect{ ClassyHash.validate({a: /the string/}, schema) }.to raise_error(ClassyHash::ValidationError, /String.*match/)
+      expect{ ClassyHash.validate({a: 'not the string'}, schema) }.to raise_error(ClassyHash::ValidationError, /String.*match/)
       expect{ ClassyHash.validate({a: 'The WHOLE String'}, schema) }.not_to raise_error
     end
 
@@ -731,16 +731,16 @@ describe ClassyHash do
 
   describe '.validate_strict' do
     it 'rejects non-hashes' do
-      expect{ ClassyHash.validate_strict(false, {}) }.to raise_error(/hash/i)
-      expect{ ClassyHash.validate_strict({}, false) }.to raise_error(/hash/i)
+      expect{ ClassyHash.validate_strict(false, {}) }.to raise_error(ClassyHash::ValidationError, /hash/i)
+      expect{ ClassyHash.validate_strict({}, false) }.to raise_error(ClassyHash::ValidationError, /hash/i)
     end
 
     context 'schema is empty' do
       it 'rejects all non-empty hashes' do
         expect{ ClassyHash.validate_strict({}, {}) }.not_to raise_error
-        expect{ ClassyHash.validate_strict({a: 1}, {}) }.to raise_error(/not specified/)
-        expect{ ClassyHash.validate_strict({[1] => [2]}, {}) }.to raise_error(/not specified/)
-        expect{ ClassyHash.validate_strict({ {} => {} }, {}) }.to raise_error(/not specified/)
+        expect{ ClassyHash.validate_strict({a: 1}, {}) }.to raise_error(ClassyHash::ValidationError, /not specified/)
+        expect{ ClassyHash.validate_strict({[1] => [2]}, {}) }.to raise_error(ClassyHash::ValidationError, /not specified/)
+        expect{ ClassyHash.validate_strict({ {} => {} }, {}) }.to raise_error(ClassyHash::ValidationError, /not specified/)
       end
     end
   end
@@ -761,7 +761,7 @@ describe ClassyHash do
 
         d[:bad].each_with_index do |info, idx|
           it "rejects bad hash #{idx}" do
-            expect{ ClassyHash.validate(info[1], d[:schema]) }.to raise_error(info[0])
+            expect{ ClassyHash.validate(info[1], d[:schema]) }.to raise_error(ClassyHash::ValidationError, info[0])
           end
         end
       end
@@ -775,19 +775,19 @@ describe ClassyHash do
           end
 
           it "rejects good hash #{idx} with extra members" do
-            expect{ ClassyHash.validate_strict(h.merge({k999: 'a', k000: :b}), d[:schema]) }.to raise_error(/contains members/)
+            expect{ ClassyHash.validate_strict(h.merge({k999: 'a', k000: :b}), d[:schema]) }.to raise_error(ClassyHash::ValidationError, /contains members/)
           end
 
           it "includes unexpected hash #{idx} keys in error message if verbose is set" do
             expect {
               ClassyHash.validate_strict(h.merge(k999: 'a', k000: :b), d[:schema], true)
-            }.to raise_error(/k999.*schema/)
+            }.to raise_error(ClassyHash::ValidationError, /k999.*schema/)
           end
         end
 
         d[:bad].each_with_index do |info, idx|
           it "rejects bad hash #{idx}" do
-            expect{ ClassyHash.validate_strict(info[1], d[:schema]) }.to raise_error(info[0])
+            expect{ ClassyHash.validate_strict(info[1], d[:schema]) }.to raise_error(ClassyHash::ValidationError, info[0])
           end
         end
       end

--- a/spec/lib/classy_hash_spec.rb
+++ b/spec/lib/classy_hash_spec.rb
@@ -793,4 +793,9 @@ describe ClassyHash do
       end
     end
   end
+  describe 'Strict nested validation', :focus do
+    it 'Should properly use strict validation on nested schemas' do
+      expect{ ClassyHash.validate_strict({ a: [{ b: 1, c: 2 }] }, { a: [[{ b: Integer }]] } )}.to raise_error(ClassyHash::ValidationError)
+    end
+  end
 end


### PR DESCRIPTION
I think this makes implementation of the library cleaner. I can rescue a specific exception instead of having a blanket rescue. 

It's also safer both for codebases using this library and this library's tests themselves as other exceptions (NilMethodError, etc) might otherwise get hidden and turned into false positives if you are not checking for a particular subclass of StandardError.

Note that RSpec suggests this also for tests for that reason.

Thanks for the Gem!
