### PR TITLE
Ruby 2.4 gemspec update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ rvm:
   - '2.0'
   - '2.1'
   - '2.2'
-  - '2.3.1'
+  - '2.3'
+  - '2.4'
   - 'jruby-9'
 script: bundle exec rspec

--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem 'msgpack', groups: [:benchmark, :test]
 gem 'rspec', '~> 3.5', group: :test
 
 # SimpleCov for offline test coverage
-gem 'simplecov', '~> 0.12.0', require: false, group: :test
+gem 'simplecov', '~> 0.15.0', require: false, group: :test
 
 # Code Climate for online test coverage
 gem 'codeclimate-test-reporter', '~> 0.6.0', require: false, group: :test

--- a/classy_hash.gemspec
+++ b/classy_hash.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'classy_hash'
-  s.version = '0.2.0'
+  s.version = '0.2.1'
   s.license = 'MIT'
   s.files = ['lib/classy_hash.rb', 'lib/classy_hash/generate.rb']
   s.summary = 'Classy Hash: Keep your Hashes classy; a Hash schema validator'
@@ -13,5 +13,5 @@ Gem::Specification.new do |s|
   s.email = ['webdev@deseretbook.com', 'mike@mikebourgeous.com']
   s.homepage = 'https://github.com/deseretbook/classy_hash'
 
-  s.required_ruby_version = ['>= 2.0', '< 2.4.0']
+  s.required_ruby_version = ['>= 2.0']
 end


### PR DESCRIPTION
Following up on issue #11, this PR updates the gem version and removes the Ruby version dependency that excludes Ruby 2.4.

Simplecov was also updated to get rid of a warning from Ruby 2.4 about the deprecation of `Fixnum`.