### PR TITLE
shift ruby support from 1.9 - 2.4 to 2.3 - 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,10 @@ env:
   global:
     - 'JRUBY_OPTS=--debug'
 rvm:
-  - '2.0'
-  - '2.1'
-  - '2.2'
   - '2.3'
   - '2.4'
+  - '2.5'
+  - '2.6'
+  - '2.7'
   - 'jruby-9'
 script: bundle exec rspec

--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem 'msgpack', groups: [:benchmark, :test]
 gem 'rspec', '~> 3.5', group: :test
 
 # SimpleCov for offline test coverage
-gem 'simplecov', '~> 0.15.0', require: false, group: :test
+gem 'simplecov', '~> 0.17.0', '< 0.18', require: false, group: :test
 
 # Code Climate for online test coverage
 gem 'codeclimate-test-reporter', '~> 0.6.0', require: false, group: :test

--- a/README.md
+++ b/README.md
@@ -505,7 +505,7 @@ schema = {
   key1: CH::G.all(Integer, 1.0..100.0)
 }
 ClassyHash.validate({ key1: 5 }, schema) # Returns true
-ClassyHash.validate({ key1: BigDecimal.new(5) }, schema) # Raises ":key1 is not all of [one of a/an Integer, a Numeric in range 1.0..100.0]"
+ClassyHash.validate({ key1: BigDecimal(5) }, schema) # Raises ":key1 is not all of [one of a/an Integer, a Numeric in range 1.0..100.0]"
 ```
 
 The `.not` generator requires all constraints to fail.

--- a/classy_hash.gemspec
+++ b/classy_hash.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'classy_hash'
-  s.version = '0.2.1'
+  s.version = '1.0.0'
   s.license = 'MIT'
   s.files = ['lib/classy_hash.rb', 'lib/classy_hash/generate.rb']
   s.summary = 'Classy Hash: Keep your Hashes classy; a Hash schema validator'
@@ -13,5 +13,5 @@ Gem::Specification.new do |s|
   s.email = ['webdev@deseretbook.com', 'mike@mikebourgeous.com']
   s.homepage = 'https://github.com/deseretbook/classy_hash'
 
-  s.required_ruby_version = ['>= 2.0']
+  s.required_ruby_version = ['>= 2.3']
 end

--- a/spec/lib/classy_hash/generate_spec.rb
+++ b/spec/lib/classy_hash/generate_spec.rb
@@ -82,7 +82,7 @@ describe CH::G do
 
     it 'rejects values matching one or more constraints' do
       expect{ CH.validate({ not: Rational(3, 5) }, not_schema) }.to raise_error(/:not.*none of.*Rational.*BigDecimal.*String/)
-      expect{ CH.validate({ not: BigDecimal.new('0.25') }, not_schema) }.to raise_error(/:not.*none of.*Rational.*BigDecimal.*String/)
+      expect{ CH.validate({ not: BigDecimal('0.25') }, not_schema) }.to raise_error(/:not.*none of.*Rational.*BigDecimal.*String/)
       expect{ CH.validate({ not: 'A string' }, not_schema) }.to raise_error(/:not.*none of.*Rational.*BigDecimal.*String/)
       expect{ CH.validate({ not: 13.0 }, not_schema) }.to raise_error(/:not.*none of.*Rational.*BigDecimal.*String/)
       expect{ CH.validate({ not: 13 }, not_schema) }.to raise_error(/:not.*none of.*Rational.*BigDecimal.*String/)


### PR DESCRIPTION
With Ruby 2.3 being EOL now, it should be reasonably safe to drop support for even older Rubies. Added support for Ruby 2.5, 2.6, and 2.7.

Also, lock `simplecov` to < 0.18 since starting with 0.18 it only supports Ruby > 2.4.
Maybe support for 2.3 should be dropped, and simplecov requirements can be relaxed.
See the simplecov release here: https://github.com/colszowka/simplecov/releases/tag/v0.17.0
Since that is only a test-dependencies, maybe it also just doesn't matter that much.

Dropping support for Ruby 1.9 in 2016 seemed to have been judged as a MINOR version change; I hope it is okay to make it a MAJOR dropping 3 Rubies that are beyond EOL. For people still on those versions, this is possibly a breaking change.

Also changed `BigDecimal.new('0.25')` to `BigDecimal('0.25')` in the specs, since `.new` is not permitted anymore since Ruby 2.7. This change is backward compatible to at least Ruby 2.3.