### PR TITLE
Added datacaster gem to alternatives in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -686,6 +686,7 @@ considered before deciding to roll our own:
 - [JSON Schema](http://json-schema.org/) ([json-schema gem](http://rubygems.org/gems/json-schema))
 - [Hash Validator](https://github.com/JamesBrooks/hash_validator)
 - [schema_hash](https://github.com/djsun/schema_hash)
+- [datacaster](https://github.com/EugZol/datacaster)
 
 ### License
 


### PR DESCRIPTION
If you will, please add my gem to alternatives. It is highly relevant to the main task of this gem and makes emphasis on richness/expressiveness of available schemas, rather than performance.